### PR TITLE
Replace/delete wrong namespace

### DIFF
--- a/docs/android/get-started/hello-android/hello-android-quickstart.md
+++ b/docs/android/get-started/hello-android/hello-android-quickstart.md
@@ -137,7 +137,7 @@ _В этом состоящем из двух частей руководств�
 ```csharp
 using System.Text;
 using System;
-namespace Core
+namespace Phoneword
 {
     public static class PhonewordTranslator
     {
@@ -241,7 +241,7 @@ Button translateButton = FindViewById<Button>(Resource.Id.TranslateButton);
 translateButton.Click += (sender, e) =>
 {
     // Translate user's alphanumeric phone number to numeric
-    string translatedNumber = Core.PhonewordTranslator.ToNumber(phoneNumberText.Text);
+    string translatedNumber = Phoneword.PhonewordTranslator.ToNumber(phoneNumberText.Text);
     if (string.IsNullOrWhiteSpace(translatedNumber))
     {
         translatedPhoneWord.Text = string.Empty;


### PR DESCRIPTION
"Phoneword" is correct namespace for this app. "Core" is wrong. You can also delete the wrong name. Then replace
string translatedNumber = Phoneword.PhonewordTranslator.ToNumber(phoneNumberText.Text);  to
string translatedNumber = PhonewordTranslator.ToNumber(phoneNumberText.Text);
Please fix.

Полезная информация для внесения предложений.
1. Изучите [краткие руководства по стилю для локализации](https://docs.microsoft.com/globalization/localization/styleguides), в которых приведены **10 наиболее важных правил** из руководства Microsoft по стилю.
2. Перейдите на [языковой портал Microsoft](https://www.microsoft.com/language), на котором содержатся **стандартизированные переводы терминов** для всех продуктов Microsoft.
